### PR TITLE
bump to v29.0.0-rc.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "SOEMAUTDServer"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 dependencies = [
  "anyhow",
  "autd3-driver",
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "TwinCATAUTDServerLightweight"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 dependencies = [
  "anyhow",
  "autd3-link-twincat",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
 name = "android-activity"
@@ -129,7 +129,7 @@ dependencies = [
  "ndk-context",
  "ndk-sys 0.5.0+25.2.9519653",
  "num_enum",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "approx"
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -473,21 +473,20 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autd3"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a39a1077558b303a4ed6c4258c5e0d3fab0da1577820f627c556dd30ec12dbae"
+checksum = "94f539059d9600dae7b936fcabe0ae6c2e97d5d9b73f62b1f876b998ebeddfce"
 dependencies = [
  "autd3-driver",
  "autd3-firmware-emulator",
  "bit-vec",
- "derivative",
  "derive-new",
  "derive_more 1.0.0",
  "itertools 0.13.0",
  "num",
  "rayon",
  "spin_sleep",
- "thiserror 1.0.68",
+ "thiserror 2.0.3",
  "tokio",
  "tracing",
  "tynm",
@@ -509,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "autd3-derive"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a79170888b784edaf75dbe878e69a81954274f3e499c7731605029655a3896d"
+checksum = "8b582277d5d7ac66519bd34c773b373e188518d30e93ad407c53cba0e50b9e39"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -521,12 +520,12 @@ dependencies = [
 
 [[package]]
 name = "autd3-driver"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0037db8344a017af410bbddc4da98bfa6175a49ce7b970f92129546eec367e"
+checksum = "56819072cb15e24c8a9c55c0ff5cf6d98df883220a4b49cf89777282fe928674"
 dependencies = [
  "async-trait",
- "autd3-derive 29.0.0-rc.5",
+ "autd3-derive 29.0.0-rc.8",
  "bit-vec",
  "bitfield-struct",
  "bitflags 2.6.0",
@@ -538,7 +537,7 @@ dependencies = [
  "rayon",
  "seq-macro",
  "serde",
- "thiserror 1.0.68",
+ "thiserror 2.0.3",
  "time",
  "tracing",
  "windows 0.58.0",
@@ -547,25 +546,25 @@ dependencies = [
 
 [[package]]
 name = "autd3-firmware-emulator"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e72eb628ac6ef52dfef35a3756a11f05fd3cc6a6e3487616bb3485f732f0a0"
+checksum = "41730f43bd502ddd3805e5399767176985d13764d274d5e8a380203f41626d44"
 dependencies = [
- "autd3-derive 29.0.0-rc.5",
+ "autd3-derive 29.0.0-rc.8",
  "autd3-driver",
  "bitfield-struct",
  "derive-new",
  "num-integer",
- "thiserror 1.0.68",
+ "thiserror 2.0.3",
  "time",
  "zerocopy 0.8.9",
 ]
 
 [[package]]
 name = "autd3-gain-holo"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29467255015be9cbae39ed20bcb59b50c34ea969a273eee44b4d1b134ecbee9f"
+checksum = "6be9001708fa022ae9f169bca1c4d20be30bd0963bb8c99e22288ee3d7c22b4e"
 dependencies = [
  "autd3-driver",
  "bit-vec",
@@ -574,16 +573,16 @@ dependencies = [
  "nalgebra 0.33.2",
  "rand 0.8.5",
  "rayon",
- "thiserror 1.0.68",
+ "thiserror 2.0.3",
  "tynm",
  "zerocopy 0.8.9",
 ]
 
 [[package]]
 name = "autd3-link-simulator"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b08fddbbbca29451fab9cd1b0d727cd72c1e99bf78026819608fc3aa543716"
+checksum = "5468c7c8f83b43053b946ac75c6de36300a99c87bf146e94b85497303755815e"
 dependencies = [
  "autd3-driver",
  "autd3-protobuf",
@@ -593,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "autd3-link-soem"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81203b197d31fe177583007adaf4c55df0987f92166d80c38eadb59b9fcc589c"
+checksum = "335fde21678993ad4ffa0efe4b9aba360ba53d4e20bb45150299f78758b0c148"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -608,7 +607,7 @@ dependencies = [
  "serde",
  "spin_sleep",
  "ta",
- "thiserror 1.0.68",
+ "thiserror 2.0.3",
  "thread-priority",
  "time",
  "tokio",
@@ -619,28 +618,28 @@ dependencies = [
 
 [[package]]
 name = "autd3-link-twincat"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a47b84866a58ab42e28964367378634ff9bbabcf5956cdc81a0e7eecfabc03a"
+checksum = "b6d14fd0bfbf79f81d935ce96c25903167300e5814e13aa5c1005ec6f8f3a2bf"
 dependencies = [
  "autd3-driver",
  "libloading 0.8.5",
- "thiserror 1.0.68",
+ "thiserror 2.0.3",
  "zerocopy 0.8.9",
 ]
 
 [[package]]
 name = "autd3-protobuf"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d603d3215faab308444b7d661493dda8b1f85da666f4caa15b62816daf8a2646"
+checksum = "23f35e75d791ea283b133cdaf23001ef131f7094d8b68e1adb7855ae23f123ce"
 dependencies = [
  "autd3",
  "autd3-driver",
  "autd3-gain-holo",
  "prost",
  "seq-macro",
- "thiserror 1.0.68",
+ "thiserror 2.0.3",
  "tokio",
  "tonic",
  "zerocopy 0.8.9",
@@ -648,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "autd3-server"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 dependencies = [
  "autd3-driver",
  "autd3-link-soem",
@@ -935,7 +934,7 @@ dependencies = [
  "glib",
  "libc",
  "once_cell",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -960,7 +959,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1017,7 +1016,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1032,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.36"
+version = "1.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baee610e9452a8f6f0a1b6194ec09ff9e2d85dea54432acdae41aa0761c95d70"
+checksum = "40545c26d092346d8a8dab71ee48e7685a7a9cba76e634790c215b41a4a7b4cf"
 dependencies = [
  "jobserver",
  "libc",
@@ -1219,6 +1218,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
 dependencies = [
  "libc",
 ]
@@ -1389,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
 dependencies = [
  "csv-core",
  "itoa 1.0.11",
@@ -1705,9 +1714,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "embed-resource"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e24052d7be71f0efb50c201557f6fe7d237cfd5a64fd5bcd7fd8fe32dbbffa"
+checksum = "b68b6f9f63a0b6a38bc447d4ce84e2b388f3ec95c99c641c8ff0dd3ef89a6379"
 dependencies = [
  "cc",
  "memchr",
@@ -1808,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "fdeflate"
@@ -1855,15 +1864,6 @@ name = "float_next_after"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
-
-[[package]]
-name = "fluent-uri"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
-dependencies = [
- "bitflags 1.3.2",
-]
 
 [[package]]
 name = "fnv"
@@ -1951,9 +1951,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1fa2f9765705486b33fd2acf1577f8ec449c2ba1f318ae5447697b7c08d210"
+checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -2221,7 +2221,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "smallvec",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2278,7 +2278,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "smallvec",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2370,7 +2370,7 @@ checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
 dependencies = [
  "log",
  "presser",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "windows 0.58.0",
 ]
 
@@ -3029,7 +3029,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -3060,37 +3060,14 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
-dependencies = [
- "jsonptr 0.4.7",
- "serde",
- "serde_json",
- "thiserror 1.0.68",
-]
-
-[[package]]
-name = "json-patch"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08"
 dependencies = [
- "jsonptr 0.6.3",
+ "jsonptr",
  "serde",
  "serde_json",
- "thiserror 1.0.68",
-]
-
-[[package]]
-name = "jsonptr"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c6e529149475ca0b2820835d3dce8fcc41c6b943ca608d32f35b449255e4627"
-dependencies = [
- "fluent-uri",
- "serde",
- "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3176,9 +3153,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libloading"
@@ -3434,7 +3411,7 @@ dependencies = [
  "once_cell",
  "png",
  "serde",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "windows-sys 0.59.0",
 ]
 
@@ -3455,7 +3432,7 @@ dependencies = [
  "rustc-hash",
  "spirv",
  "termcolor",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "unicode-xid",
 ]
 
@@ -3515,7 +3492,7 @@ dependencies = [
  "ndk-sys 0.5.0+25.2.9519653",
  "num_enum",
  "raw-window-handle",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3530,7 +3507,7 @@ dependencies = [
  "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4412,9 +4389,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.3"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -4730,7 +4707,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4741,7 +4718,7 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.8",
+ "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
 ]
 
@@ -4756,9 +4733,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4868,7 +4845,7 @@ checksum = "4054c51e241d0c6d57fab9fecda2223b7bdc7621be67f0d70568d94a6762f281"
 dependencies = [
  "nix 0.26.4",
  "rustbus_derive",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4905,9 +4882,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.39"
+version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375116bee2be9ed569afe2154ea6a99dfdffd257f533f187498c2a8f5feaf4ee"
+checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -5053,9 +5030,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
@@ -5073,9 +5050,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5301,7 +5278,7 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simulator"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 dependencies = [
  "anyhow",
  "autd3-derive 28.1.0",
@@ -5325,7 +5302,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "strum",
- "thiserror 2.0.0",
+ "thiserror 2.0.3",
  "tokio",
  "tonic",
  "tracing",
@@ -5379,7 +5356,7 @@ dependencies = [
  "log",
  "memmap2",
  "rustix",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -5645,9 +5622,9 @@ checksum = "609409d472a0a7d8d4dd9e19891bbdef546b9dce670c3057d0e02192dc541226"
 
 [[package]]
 name = "tao"
-version = "0.30.5"
+version = "0.30.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f1f6b2017cc33d7f6fc9c6186a2c0f5dfc985899a7b4fe9e64985c17533db3"
+checksum = "6682a07cf5bab0b8a2bd20d0a542917ab928b5edb75ebd4eda6b05cbaab872da"
 dependencies = [
  "bitflags 2.6.0",
  "cocoa",
@@ -5701,9 +5678,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.0.6"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3889b392db6d32a105d3757230ea0220090b8f94c90d3e60b6c5eb91178ab1b"
+checksum = "e545de0a2dfe296fa67db208266cd397c5a55ae782da77973ef4c4fac90e9f2c"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5738,7 +5715,7 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "tauri-utils",
- "thiserror 1.0.68",
+ "thiserror 2.0.3",
  "tokio",
  "tray-icon",
  "url",
@@ -5751,16 +5728,16 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f96827ccfb1aa40d55d0ded79562d18ba18566657a553f992a982d755148376"
+checksum = "7bd2a4bcfaf5fb9f4be72520eefcb61ae565038f8ccba2a497d8c28f463b8c01"
 dependencies = [
  "anyhow",
  "cargo_toml",
  "dirs",
  "glob",
  "heck 0.5.0",
- "json-patch 3.0.1",
+ "json-patch",
  "schemars",
  "semver",
  "serde",
@@ -5773,14 +5750,14 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947f16f47becd9e9cd39b74ee337fd1981574d78819be18e4384d85e5a0b82f"
+checksum = "bf79faeecf301d3e969b1fae977039edb77a4c1f25cc0a961be298b54bff97cf"
 dependencies = [
  "base64 0.22.1",
  "brotli",
  "ico",
- "json-patch 2.0.0",
+ "json-patch",
  "plist",
  "png",
  "proc-macro2",
@@ -5791,7 +5768,7 @@ dependencies = [
  "sha2",
  "syn 2.0.87",
  "tauri-utils",
- "thiserror 1.0.68",
+ "thiserror 2.0.3",
  "time",
  "url",
  "uuid",
@@ -5800,9 +5777,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd1c8d4a66799d3438747c3a79705cd665a95d6f24cb5f315413ff7a981fe2a"
+checksum = "c52027c8c5afb83166dacddc092ee8fff50772f9646d461d8c33ee887e447a03"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5814,9 +5791,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa4e6c94cb1d635f65a770c69e23de1bc054b0e4c554fa037a7cc7676333d39"
+checksum = "e753f2a30933a9bbf0a202fa47d7cc4a3401f06e8d6dcc53b79aa62954828c79"
 dependencies = [
  "anyhow",
  "glob",
@@ -5843,7 +5820,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-plugin-fs",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "url",
 ]
 
@@ -5863,7 +5840,7 @@ dependencies = [
  "serde_repr",
  "tauri",
  "tauri-plugin",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "url",
  "uuid",
 ]
@@ -5882,7 +5859,7 @@ dependencies = [
  "serde_repr",
  "tauri",
  "tauri-plugin",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "time",
  "url",
 ]
@@ -5902,7 +5879,7 @@ dependencies = [
  "sys-locale",
  "tauri",
  "tauri-plugin",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5922,15 +5899,15 @@ dependencies = [
  "shared_child",
  "tauri",
  "tauri-plugin",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
 [[package]]
 name = "tauri-runtime"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ef7363e7229ac8d04e8a5d405670dbd43dde8fc4bc3bc56105c35452d03784"
+checksum = "cce18d43f80d4aba3aa8a0c953bbe835f3d0f2370aca75e8dbb14bd4bab27958"
 dependencies = [
  "dpi",
  "gtk",
@@ -5940,16 +5917,16 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "thiserror 1.0.68",
+ "thiserror 2.0.3",
  "url",
  "windows 0.58.0",
 ]
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fa2068e8498ad007b54d5773d03d57c3ff6dd96f8c8ce58beff44d0d5e0d30"
+checksum = "9f442a38863e10129ffe2cec7bd09c2dcf8a098a3a27801a476a304d5bb991d2"
 dependencies = [
  "gtk",
  "http",
@@ -5973,9 +5950,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc65d6f5c54e56b66258948a6d9e47a82ea41f4b5a7612bfbdd1634c2913ed0"
+checksum = "9271a88f99b4adea0dc71d0baca4505475a0bbd139fb135f62958721aaa8fe54"
 dependencies = [
  "brotli",
  "cargo_metadata",
@@ -5983,8 +5960,9 @@ dependencies = [
  "dunce",
  "glob",
  "html5ever",
+ "http",
  "infer",
- "json-patch 2.0.0",
+ "json-patch",
  "kuchikiki",
  "log",
  "memchr",
@@ -5999,7 +5977,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "swift-rs",
- "thiserror 1.0.68",
+ "thiserror 2.0.3",
  "toml 0.8.2",
  "url",
  "urlpattern",
@@ -6030,9 +6008,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -6069,27 +6047,27 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.68",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.0"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15291287e9bff1bc6f9ff3409ed9af665bec7a5fc8ac079ea96be07bca0e2668"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
 dependencies = [
- "thiserror-impl 2.0.0",
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6098,9 +6076,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.0"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22efd00f33f93fa62848a7cab956c3d38c8d43095efda1decfc2b3a5dc0b8972"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6109,9 +6087,9 @@ dependencies = [
 
 [[package]]
 name = "thread-priority"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3b04d33c9633b8662b167b847c7ab521f83d1ae20f2321b65b5b925e532e36"
+checksum = "cfe075d7053dae61ac5413a34ea7d4913b6e6207844fd726bdd858b37ff72bf5"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -6199,9 +6177,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6463,7 +6441,7 @@ dependencies = [
  "once_cell",
  "png",
  "serde",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "windows-sys 0.59.0",
 ]
 
@@ -7014,7 +6992,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3a3e2eeb58f82361c93f9777014668eb3d07e7d174ee4c819575a9208011886"
 dependencies = [
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "windows 0.58.0",
  "windows-core 0.58.0",
 ]
@@ -7066,7 +7044,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "smallvec",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "wgpu-hal",
  "wgpu-types",
 ]
@@ -7108,7 +7086,7 @@ dependencies = [
  "renderdoc-sys",
  "rustc-hash",
  "smallvec",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -7634,12 +7612,13 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wry"
-version = "0.46.3"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd5cdf57c66813d97601181349c63b96994b3074fc3d7a31a8cce96e968e3bbd"
+checksum = "553ca1ce149982123962fac2506aa75b8b76288779a77e72b12fa2fc34938647"
 dependencies = [
  "base64 0.22.1",
  "block2 0.5.1",
+ "cookie",
  "crossbeam-channel",
  "dpi",
  "dunce",
@@ -7663,7 +7642,8 @@ dependencies = [
  "sha2",
  "soup3",
  "tao-macros",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
+ "url",
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
@@ -7752,9 +7732,9 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"
+checksum = "af310deaae937e48a26602b730250b4949e125f468f11e6990be3e5304ddd96f"
 
 [[package]]
 name = "yoke"

--- a/SOEMAUTDServer/Cargo.toml
+++ b/SOEMAUTDServer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "SOEMAUTDServer"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 authors = ["shun suzuki <suzuki@hapis.k.u-tokyo.ac.jp>"]
 edition = "2021"
 license = "MIT"
@@ -13,9 +13,9 @@ keywords = ["autd"]
 [dependencies]
 clap = { version = "4.5.19", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }
-autd3-protobuf = { version = "29.0.0-rc.5", features = ["lightweight", "async-trait"] }
-autd3-link-soem = { version = "29.0.0-rc.5", features = ["async-trait"] }
-autd3-driver = { version = "29.0.0-rc.5", features = ["async-trait"] }
+autd3-protobuf = { version = "29.0.0-rc.8", features = ["lightweight", "async-trait"] }
+autd3-link-soem = { version = "29.0.0-rc.8", features = ["async-trait"] }
+autd3-driver = { version = "29.0.0-rc.8", features = ["async-trait"] }
 anyhow = "1.0.92"
 ctrlc = "3.4.5"
 tonic = "0.12.3"

--- a/SOEMAUTDServer/ThirdPartyNotice.txt
+++ b/SOEMAUTDServer/ThirdPartyNotice.txt
@@ -6,7 +6,7 @@ The license terms for each of these components are provided later in this notice
 
 ---------------------------------------------------------
 
-SOEMAUTDServer 29.0.0-rc.5 (MIT)
+SOEMAUTDServer 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-server
 ---------------------------------------------------------
 
@@ -50,7 +50,7 @@ anstyle-wincon 3.0.6 (Apache-2.0 OR MIT)
 https://github.com/rust-cli/anstyle.git
 ---------------------------------------------------------
 
-anyhow 1.0.92 (Apache-2.0 OR MIT)
+anyhow 1.0.93 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/anyhow
 ---------------------------------------------------------
 
@@ -78,31 +78,31 @@ atomic-waker 1.1.2 (Apache-2.0 OR MIT)
 https://github.com/smol-rs/atomic-waker
 ---------------------------------------------------------
 
-autd3 29.0.0-rc.5 (MIT)
+autd3 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-derive 29.0.0-rc.5 (MIT)
+autd3-derive 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-driver 29.0.0-rc.5 (MIT)
+autd3-driver 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-firmware-emulator 29.0.0-rc.5 (MIT)
+autd3-firmware-emulator 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-gain-holo 29.0.0-rc.5 (MIT)
+autd3-gain-holo 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-link-soem 29.0.0-rc.5 (MIT)
+autd3-link-soem 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-link-soem
 ---------------------------------------------------------
 
-autd3-protobuf 29.0.0-rc.5 (MIT)
+autd3-protobuf 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
@@ -212,10 +212,6 @@ https://github.com/Detegr/rust-ctrlc.git
 
 deranged 0.3.11 (Apache-2.0 OR MIT)
 https://github.com/jhpratt/deranged
----------------------------------------------------------
-
-derivative 2.2.0 (Apache-2.0 OR MIT)
-https://github.com/mcarton/rust-derivative
 ---------------------------------------------------------
 
 derive-new 0.7.0 (MIT)
@@ -374,7 +370,7 @@ lazy_static 1.5.0 (Apache-2.0 OR MIT)
 https://github.com/rust-lang-nursery/lazy-static.rs
 ---------------------------------------------------------
 
-libc 0.2.161 (Apache-2.0 OR MIT)
+libc 0.2.162 (Apache-2.0 OR MIT)
 https://github.com/rust-lang/libc
 ---------------------------------------------------------
 
@@ -566,7 +562,7 @@ regex-automata 0.1.10 (MIT OR Unlicense)
 https://github.com/BurntSushi/regex-automata
 ---------------------------------------------------------
 
-regex-automata 0.4.8 (Apache-2.0 OR MIT)
+regex-automata 0.4.9 (Apache-2.0 OR MIT)
 https://github.com/rust-lang/regex/tree/master/regex-automata
 ---------------------------------------------------------
 
@@ -594,11 +590,11 @@ seq-macro 0.3.5 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/seq-macro
 ---------------------------------------------------------
 
-serde 1.0.214 (Apache-2.0 OR MIT)
+serde 1.0.215 (Apache-2.0 OR MIT)
 https://github.com/serde-rs/serde
 ---------------------------------------------------------
 
-serde_derive 1.0.214 (Apache-2.0 OR MIT)
+serde_derive 1.0.215 (Apache-2.0 OR MIT)
 https://github.com/serde-rs/serde
 ---------------------------------------------------------
 
@@ -638,10 +634,6 @@ strsim 0.11.1 (MIT)
 https://github.com/rapidfuzz/strsim-rs
 ---------------------------------------------------------
 
-syn 1.0.109 (Apache-2.0 OR MIT)
-https://github.com/dtolnay/syn
----------------------------------------------------------
-
 syn 2.0.87 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/syn
 ---------------------------------------------------------
@@ -658,15 +650,15 @@ ta 0.5.0 (MIT)
 https://github.com/greyblake/ta-rs
 ---------------------------------------------------------
 
-thiserror 1.0.68 (Apache-2.0 OR MIT)
+thiserror 2.0.3 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/thiserror
 ---------------------------------------------------------
 
-thiserror-impl 1.0.68 (Apache-2.0 OR MIT)
+thiserror-impl 2.0.3 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/thiserror
 ---------------------------------------------------------
 
-thread-priority 1.1.0 (MIT)
+thread-priority 1.2.0 (MIT)
 https://github.com/iddm/thread-priority
 ---------------------------------------------------------
 
@@ -686,7 +678,7 @@ time-macros 0.2.18 (Apache-2.0 OR MIT)
 https://github.com/time-rs/time
 ---------------------------------------------------------
 
-tokio 1.41.0 (MIT)
+tokio 1.41.1 (MIT)
 https://github.com/tokio-rs/tokio
 ---------------------------------------------------------
 

--- a/ThirdPartyNotice.txt
+++ b/ThirdPartyNotice.txt
@@ -6,7 +6,7 @@ The license terms for each of these components are provided later in this notice
 
 ---------------------------------------------------------
 
-@tauri-apps/api 2.0.3 Apache-2.0 OR MIT
+@tauri-apps/api 2.1.1 Apache-2.0 OR MIT
 git+https://github.com/tauri-apps/tauri.git
 ---------------------------------------------------------
 

--- a/TwinCATAUTDServerLightweight/Cargo.toml
+++ b/TwinCATAUTDServerLightweight/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "TwinCATAUTDServerLightweight"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 authors = ["shun suzuki <suzuki@hapis.k.u-tokyo.ac.jp>"]
 edition = "2021"
 license = "MIT"
@@ -13,8 +13,8 @@ keywords = ["autd"]
 [dependencies]
 clap = { version = "4.5.19", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }
-autd3-protobuf = { version = "29.0.0-rc.5", features = ["lightweight", "async-trait"] }
-autd3-link-twincat = { version = "29.0.0-rc.5", features = ["async-trait"] }
+autd3-protobuf = { version = "29.0.0-rc.8", features = ["lightweight", "async-trait"] }
+autd3-link-twincat = { version = "29.0.0-rc.8", features = ["async-trait"] }
 anyhow = "1.0.92"
 ctrlc = "3.4.5"
 tonic = "0.12.3"

--- a/TwinCATAUTDServerLightweight/ThirdPartyNotice.txt
+++ b/TwinCATAUTDServerLightweight/ThirdPartyNotice.txt
@@ -6,7 +6,7 @@ The license terms for each of these components are provided later in this notice
 
 ---------------------------------------------------------
 
-TwinCATAUTDServerLightweight 29.0.0-rc.5 (MIT)
+TwinCATAUTDServerLightweight 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-server
 ---------------------------------------------------------
 
@@ -50,7 +50,7 @@ anstyle-wincon 3.0.6 (Apache-2.0 OR MIT)
 https://github.com/rust-cli/anstyle.git
 ---------------------------------------------------------
 
-anyhow 1.0.92 (Apache-2.0 OR MIT)
+anyhow 1.0.93 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/anyhow
 ---------------------------------------------------------
 
@@ -74,31 +74,31 @@ atomic-waker 1.1.2 (Apache-2.0 OR MIT)
 https://github.com/smol-rs/atomic-waker
 ---------------------------------------------------------
 
-autd3 29.0.0-rc.5 (MIT)
+autd3 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-derive 29.0.0-rc.5 (MIT)
+autd3-derive 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-driver 29.0.0-rc.5 (MIT)
+autd3-driver 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-firmware-emulator 29.0.0-rc.5 (MIT)
+autd3-firmware-emulator 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-gain-holo 29.0.0-rc.5 (MIT)
+autd3-gain-holo 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-link-twincat 29.0.0-rc.5 (MIT)
+autd3-link-twincat 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-protobuf 29.0.0-rc.5 (MIT)
+autd3-protobuf 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
@@ -204,10 +204,6 @@ https://github.com/Detegr/rust-ctrlc.git
 
 deranged 0.3.11 (Apache-2.0 OR MIT)
 https://github.com/jhpratt/deranged
----------------------------------------------------------
-
-derivative 2.2.0 (Apache-2.0 OR MIT)
-https://github.com/mcarton/rust-derivative
 ---------------------------------------------------------
 
 derive-new 0.7.0 (MIT)
@@ -358,7 +354,7 @@ lazy_static 1.5.0 (Apache-2.0 OR MIT)
 https://github.com/rust-lang-nursery/lazy-static.rs
 ---------------------------------------------------------
 
-libc 0.2.161 (Apache-2.0 OR MIT)
+libc 0.2.162 (Apache-2.0 OR MIT)
 https://github.com/rust-lang/libc
 ---------------------------------------------------------
 
@@ -550,7 +546,7 @@ regex-automata 0.1.10 (MIT OR Unlicense)
 https://github.com/BurntSushi/regex-automata
 ---------------------------------------------------------
 
-regex-automata 0.4.8 (Apache-2.0 OR MIT)
+regex-automata 0.4.9 (Apache-2.0 OR MIT)
 https://github.com/rust-lang/regex/tree/master/regex-automata
 ---------------------------------------------------------
 
@@ -578,11 +574,11 @@ seq-macro 0.3.5 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/seq-macro
 ---------------------------------------------------------
 
-serde 1.0.214 (Apache-2.0 OR MIT)
+serde 1.0.215 (Apache-2.0 OR MIT)
 https://github.com/serde-rs/serde
 ---------------------------------------------------------
 
-serde_derive 1.0.214 (Apache-2.0 OR MIT)
+serde_derive 1.0.215 (Apache-2.0 OR MIT)
 https://github.com/serde-rs/serde
 ---------------------------------------------------------
 
@@ -622,10 +618,6 @@ strsim 0.11.1 (MIT)
 https://github.com/rapidfuzz/strsim-rs
 ---------------------------------------------------------
 
-syn 1.0.109 (Apache-2.0 OR MIT)
-https://github.com/dtolnay/syn
----------------------------------------------------------
-
 syn 2.0.87 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/syn
 ---------------------------------------------------------
@@ -638,11 +630,11 @@ sync_wrapper 1.0.1 (Apache-2.0)
 https://github.com/Actyx/sync_wrapper
 ---------------------------------------------------------
 
-thiserror 1.0.68 (Apache-2.0 OR MIT)
+thiserror 2.0.3 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/thiserror
 ---------------------------------------------------------
 
-thiserror-impl 1.0.68 (Apache-2.0 OR MIT)
+thiserror-impl 2.0.3 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/thiserror
 ---------------------------------------------------------
 
@@ -662,7 +654,7 @@ time-macros 0.2.18 (Apache-2.0 OR MIT)
 https://github.com/time-rs/time
 ---------------------------------------------------------
 
-tokio 1.41.0 (MIT)
+tokio 1.41.1 (MIT)
 https://github.com/tokio-rs/tokio
 ---------------------------------------------------------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autd3-server",
-  "version": "29.0.0-rc.5",
+  "version": "29.0.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autd3-server",
-      "version": "29.0.0-rc.5",
+      "version": "29.0.0-rc.8",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-dialog": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "autd3-server",
   "type": "module",
-  "version": "29.0.0-rc.5",
+  "version": "29.0.0-rc.8",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simulator"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 edition = "2021"
 authors = ["shun suzuki <suzuki@hapis.k.u-tokyo.ac.jp>"]
 
@@ -12,10 +12,10 @@ keywords = ["autd"]
 [dependencies]
 anyhow = "1.0.92"
 autd3-derive = "28.0.1"
-autd3-driver = { version = "29.0.0-rc.5", features = ["async-trait"] }
-autd3-firmware-emulator = { version = "29.0.0-rc.5", features = ["async-trait"] }
-autd3-link-simulator = { version = "29.0.0-rc.5", features = ["async-trait"] }
-autd3-protobuf = { version = "29.0.0-rc.5", features = ["async-trait", "lightweight"] }
+autd3-driver = { version = "29.0.0-rc.8", features = ["async-trait"] }
+autd3-firmware-emulator = { version = "29.0.0-rc.8", features = ["async-trait"] }
+autd3-link-simulator = { version = "29.0.0-rc.8", features = ["async-trait"] }
+autd3-protobuf = { version = "29.0.0-rc.8", features = ["async-trait", "lightweight"] }
 bitflags = "2.6.0"
 bytemuck = { version = "1.19.0", features = ["derive"] }
 camera_controllers = "0.34.0"

--- a/simulator/ThirdPartyNotice.txt
+++ b/simulator/ThirdPartyNotice.txt
@@ -30,7 +30,7 @@ aho-corasick 1.1.3 (MIT OR Unlicense)
 https://github.com/BurntSushi/aho-corasick
 ---------------------------------------------------------
 
-allocator-api2 0.2.18 (Apache-2.0 OR MIT)
+allocator-api2 0.2.20 (Apache-2.0 OR MIT)
 https://github.com/zakarumych/allocator-api2
 ---------------------------------------------------------
 
@@ -70,7 +70,7 @@ anstyle-wincon 3.0.6 (Apache-2.0 OR MIT)
 https://github.com/rust-cli/anstyle.git
 ---------------------------------------------------------
 
-anyhow 1.0.92 (Apache-2.0 OR MIT)
+anyhow 1.0.93 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/anyhow
 ---------------------------------------------------------
 
@@ -114,7 +114,7 @@ atomic-waker 1.1.2 (Apache-2.0 OR MIT)
 https://github.com/smol-rs/atomic-waker
 ---------------------------------------------------------
 
-autd3 29.0.0-rc.5 (MIT)
+autd3 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
@@ -122,27 +122,27 @@ autd3-derive 28.1.0 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-derive 29.0.0-rc.5 (MIT)
+autd3-derive 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-driver 29.0.0-rc.5 (MIT)
+autd3-driver 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-firmware-emulator 29.0.0-rc.5 (MIT)
+autd3-firmware-emulator 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-gain-holo 29.0.0-rc.5 (MIT)
+autd3-gain-holo 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-link-simulator 29.0.0-rc.5 (MIT)
+autd3-link-simulator 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-protobuf 29.0.0-rc.5 (MIT)
+autd3-protobuf 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
@@ -322,7 +322,7 @@ crossbeam-utils 0.8.20 (Apache-2.0 OR MIT)
 https://github.com/crossbeam-rs/crossbeam
 ---------------------------------------------------------
 
-csv 1.3.0 (MIT OR Unlicense)
+csv 1.3.1 (MIT OR Unlicense)
 https://github.com/BurntSushi/rust-csv
 ---------------------------------------------------------
 
@@ -336,10 +336,6 @@ https://github.com/rust-windowing/cursor-icon
 
 deranged 0.3.11 (Apache-2.0 OR MIT)
 https://github.com/jhpratt/deranged
----------------------------------------------------------
-
-derivative 2.2.0 (Apache-2.0 OR MIT)
-https://github.com/mcarton/rust-derivative
 ---------------------------------------------------------
 
 derive-new 0.7.0 (MIT)
@@ -646,7 +642,7 @@ lazy_static 1.5.0 (Apache-2.0 OR MIT)
 https://github.com/rust-lang-nursery/lazy-static.rs
 ---------------------------------------------------------
 
-libc 0.2.161 (Apache-2.0 OR MIT)
+libc 0.2.162 (Apache-2.0 OR MIT)
 https://github.com/rust-lang/libc
 ---------------------------------------------------------
 
@@ -894,7 +890,7 @@ png 0.17.14 (Apache-2.0 OR MIT)
 https://github.com/image-rs/image-png
 ---------------------------------------------------------
 
-polling 3.7.3 (Apache-2.0 OR MIT)
+polling 3.7.4 (Apache-2.0 OR MIT)
 https://github.com/smol-rs/polling
 ---------------------------------------------------------
 
@@ -990,7 +986,7 @@ regex-automata 0.1.10 (MIT OR Unlicense)
 https://github.com/BurntSushi/regex-automata
 ---------------------------------------------------------
 
-regex-automata 0.4.8 (Apache-2.0 OR MIT)
+regex-automata 0.4.9 (Apache-2.0 OR MIT)
 https://github.com/rust-lang/regex/tree/master/regex-automata
 ---------------------------------------------------------
 
@@ -1021,7 +1017,7 @@ rustc-hash 1.1.0 (Apache-2.0 OR MIT)
 https://github.com/rust-lang-nursery/rustc-hash
 ---------------------------------------------------------
 
-rustix 0.38.39 (Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT)
+rustix 0.38.40 (Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT)
 https://github.com/bytecodealliance/rustix
 ---------------------------------------------------------
 
@@ -1057,11 +1053,11 @@ seq-macro 0.3.5 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/seq-macro
 ---------------------------------------------------------
 
-serde 1.0.214 (Apache-2.0 OR MIT)
+serde 1.0.215 (Apache-2.0 OR MIT)
 https://github.com/serde-rs/serde
 ---------------------------------------------------------
 
-serde_derive 1.0.214 (Apache-2.0 OR MIT)
+serde_derive 1.0.215 (Apache-2.0 OR MIT)
 https://github.com/serde-rs/serde
 ---------------------------------------------------------
 
@@ -1093,7 +1089,7 @@ simd-adler32 0.3.7 (MIT)
 https://github.com/mcountryman/simd-adler32
 ---------------------------------------------------------
 
-simulator 29.0.0-rc.5 (MIT)
+simulator 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-server
 ---------------------------------------------------------
 
@@ -1157,10 +1153,6 @@ strum_macros 0.26.4 (MIT)
 https://github.com/Peternator7/strum
 ---------------------------------------------------------
 
-syn 1.0.109 (Apache-2.0 OR MIT)
-https://github.com/dtolnay/syn
----------------------------------------------------------
-
 syn 2.0.87 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/syn
 ---------------------------------------------------------
@@ -1177,19 +1169,19 @@ termcolor 1.4.1 (MIT OR Unlicense)
 https://github.com/BurntSushi/termcolor
 ---------------------------------------------------------
 
-thiserror 1.0.68 (Apache-2.0 OR MIT)
+thiserror 1.0.69 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/thiserror
 ---------------------------------------------------------
 
-thiserror 2.0.0 (Apache-2.0 OR MIT)
+thiserror 2.0.3 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/thiserror
 ---------------------------------------------------------
 
-thiserror-impl 1.0.68 (Apache-2.0 OR MIT)
+thiserror-impl 1.0.69 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/thiserror
 ---------------------------------------------------------
 
-thiserror-impl 2.0.0 (Apache-2.0 OR MIT)
+thiserror-impl 2.0.3 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/thiserror
 ---------------------------------------------------------
 
@@ -1217,7 +1209,7 @@ tiny-skia-path 0.11.4 (BSD-3-Clause)
 https://github.com/RazrFalcon/tiny-skia/tree/master/path
 ---------------------------------------------------------
 
-tokio 1.41.0 (MIT)
+tokio 1.41.1 (MIT)
 https://github.com/tokio-rs/tokio
 ---------------------------------------------------------
 

--- a/simulator/src/server.rs
+++ b/simulator/src/server.rs
@@ -90,6 +90,7 @@ pub struct ServerWrapper {
         std::thread::JoinHandle<Result<(), tonic::transport::Error>>,
         tokio::sync::oneshot::Sender<()>,
     )>,
+    port: u16,
 }
 
 impl ServerWrapper {
@@ -168,6 +169,7 @@ impl ServerWrapper {
             receiver: rx,
             shutdown: tx_shutdown,
             lightweight_server,
+            port,
         }
     }
 
@@ -237,6 +239,11 @@ impl ServerWrapper {
             }
             Ok(Signal::Close) => {
                 state.clear();
+                tracing::info!("Server is closed by client");
+                tracing::info!(
+                    "Waiting for client connection on http://0.0.0.0:{}",
+                    self.port
+                );
             }
             Err(TryRecvError::Empty) => {}
             _ => {}

--- a/simulator/src/simulator.rs
+++ b/simulator/src/simulator.rs
@@ -80,7 +80,9 @@ impl Simulator {
             }
         });
 
+        tracing::info!("Shutting down server...");
         server.shutdown();
+        tracing::info!("Shutting down server...done");
 
         res?;
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "autd3-server"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 description = "AUTD3 Server app"
 authors = ["shun suzuki <suzuki@hapis.k.u-tokyo.ac.jp>"]
 edition = "2021"
@@ -20,8 +20,8 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread", "time", "process"] }
 tauri = { version = "2", features = [] }
-autd3-driver = { version = "29.0.0-rc.5", features = ["serde"] }
-autd3-link-soem = { version = "29.0.0-rc.5", features = ["serde"] }
+autd3-driver = { version = "29.0.0-rc.8", features = ["serde"] }
+autd3-link-soem = { version = "29.0.0-rc.8", features = ["serde"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/ThirdPartyNotice.txt
+++ b/src-tauri/ThirdPartyNotice.txt
@@ -34,7 +34,7 @@ android_system_properties 0.1.5 (Apache-2.0 OR MIT)
 https://github.com/nical/android_system_properties
 ---------------------------------------------------------
 
-anyhow 1.0.92 (Apache-2.0 OR MIT)
+anyhow 1.0.93 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/anyhow
 ---------------------------------------------------------
 
@@ -62,7 +62,7 @@ async-fs 2.1.2 (Apache-2.0 OR MIT)
 https://github.com/smol-rs/async-fs
 ---------------------------------------------------------
 
-async-io 2.3.4 (Apache-2.0 OR MIT)
+async-io 2.4.0 (Apache-2.0 OR MIT)
 https://github.com/smol-rs/async-io
 ---------------------------------------------------------
 
@@ -110,35 +110,35 @@ atomic-waker 1.1.2 (Apache-2.0 OR MIT)
 https://github.com/smol-rs/atomic-waker
 ---------------------------------------------------------
 
-autd3 29.0.0-rc.5 (MIT)
+autd3 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-derive 29.0.0-rc.5 (MIT)
+autd3-derive 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-driver 29.0.0-rc.5 (MIT)
+autd3-driver 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-firmware-emulator 29.0.0-rc.5 (MIT)
+autd3-firmware-emulator 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-gain-holo 29.0.0-rc.5 (MIT)
+autd3-gain-holo 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-link-soem 29.0.0-rc.5 (MIT)
+autd3-link-soem 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-link-soem
 ---------------------------------------------------------
 
-autd3-protobuf 29.0.0-rc.5 (MIT)
+autd3-protobuf 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-rs
 ---------------------------------------------------------
 
-autd3-server 29.0.0-rc.5 (MIT)
+autd3-server 29.0.0-rc.8 (MIT)
 https://github.com/shinolab/autd3-server
 ---------------------------------------------------------
 
@@ -282,6 +282,10 @@ convert_case 0.4.0 (MIT)
 https://github.com/rutrum/convert-case
 ---------------------------------------------------------
 
+cookie 0.18.1 (Apache-2.0 OR MIT)
+https://github.com/SergioBenitez/cookie-rs
+---------------------------------------------------------
+
 core-foundation 0.10.0 (Apache-2.0 OR MIT)
 https://github.com/servo/core-foundation-rs
 ---------------------------------------------------------
@@ -298,7 +302,7 @@ core-graphics-types 0.2.0 (Apache-2.0 OR MIT)
 https://github.com/servo/core-foundation-rs
 ---------------------------------------------------------
 
-cpufeatures 0.2.14 (Apache-2.0 OR MIT)
+cpufeatures 0.2.15 (Apache-2.0 OR MIT)
 https://github.com/RustCrypto/utils
 ---------------------------------------------------------
 
@@ -481,7 +485,7 @@ event-listener-strategy 0.5.2 (Apache-2.0 OR MIT)
 https://github.com/smol-rs/event-listener-strategy
 ---------------------------------------------------------
 
-fastrand 2.1.1 (Apache-2.0 OR MIT)
+fastrand 2.2.0 (Apache-2.0 OR MIT)
 https://github.com/smol-rs/fastrand
 ---------------------------------------------------------
 
@@ -495,10 +499,6 @@ https://github.com/Diggsey/rust-field-offset
 
 flate2 1.0.34 (Apache-2.0 OR MIT)
 https://github.com/rust-lang/flate2-rs
----------------------------------------------------------
-
-fluent-uri 0.1.4 (MIT)
-https://github.com/yescallop/fluent-uri-rs
 ---------------------------------------------------------
 
 fnv 1.0.7 (Apache-2.0 OR MIT)
@@ -541,7 +541,7 @@ futures-io 0.3.31 (Apache-2.0 OR MIT)
 https://github.com/rust-lang/futures-rs
 ---------------------------------------------------------
 
-futures-lite 2.4.0 (Apache-2.0 OR MIT)
+futures-lite 2.5.0 (Apache-2.0 OR MIT)
 https://github.com/smol-rs/futures-lite
 ---------------------------------------------------------
 
@@ -845,11 +845,11 @@ js-sys 0.3.72 (Apache-2.0 OR MIT)
 https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys
 ---------------------------------------------------------
 
-json-patch 2.0.0 (Apache-2.0 OR MIT)
+json-patch 3.0.1 (Apache-2.0 OR MIT)
 https://github.com/idubrov/json-patch
 ---------------------------------------------------------
 
-jsonptr 0.4.7 (Apache-2.0 OR MIT)
+jsonptr 0.6.3 (Apache-2.0 OR MIT)
 https://github.com/chanced/jsonptr
 ---------------------------------------------------------
 
@@ -871,7 +871,7 @@ libappindicator 0.9.0 (Apache-2.0 OR MIT)
 libappindicator-sys 0.9.0 (Apache-2.0 OR MIT)
 ---------------------------------------------------------
 
-libc 0.2.161 (Apache-2.0 OR MIT)
+libc 0.2.162 (Apache-2.0 OR MIT)
 https://github.com/rust-lang/libc
 ---------------------------------------------------------
 
@@ -1263,7 +1263,7 @@ png 0.17.14 (Apache-2.0 OR MIT)
 https://github.com/image-rs/image-png
 ---------------------------------------------------------
 
-polling 3.7.3 (Apache-2.0 OR MIT)
+polling 3.7.4 (Apache-2.0 OR MIT)
 https://github.com/smol-rs/polling
 ---------------------------------------------------------
 
@@ -1387,7 +1387,7 @@ regex 1.11.1 (Apache-2.0 OR MIT)
 https://github.com/rust-lang/regex
 ---------------------------------------------------------
 
-regex-automata 0.4.8 (Apache-2.0 OR MIT)
+regex-automata 0.4.9 (Apache-2.0 OR MIT)
 https://github.com/rust-lang/regex/tree/master/regex-automata
 ---------------------------------------------------------
 
@@ -1413,7 +1413,7 @@ rustc-demangle 0.1.24 (Apache-2.0 OR MIT)
 https://github.com/rust-lang/rustc-demangle
 ---------------------------------------------------------
 
-rustix 0.38.39 (Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT)
+rustix 0.38.40 (Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT)
 https://github.com/bytecodealliance/rustix
 ---------------------------------------------------------
 
@@ -1461,7 +1461,7 @@ seq-macro 0.3.5 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/seq-macro
 ---------------------------------------------------------
 
-serde 1.0.214 (Apache-2.0 OR MIT)
+serde 1.0.215 (Apache-2.0 OR MIT)
 https://github.com/serde-rs/serde
 ---------------------------------------------------------
 
@@ -1469,7 +1469,7 @@ serde-untagged 0.1.6 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/serde-untagged
 ---------------------------------------------------------
 
-serde_derive 1.0.214 (Apache-2.0 OR MIT)
+serde_derive 1.0.215 (Apache-2.0 OR MIT)
 https://github.com/serde-rs/serde
 ---------------------------------------------------------
 
@@ -1621,7 +1621,7 @@ ta 0.5.0 (MIT)
 https://github.com/greyblake/ta-rs
 ---------------------------------------------------------
 
-tao 0.30.5 (Apache-2.0)
+tao 0.30.8 (Apache-2.0)
 https://github.com/tauri-apps/tao
 ---------------------------------------------------------
 
@@ -1629,15 +1629,15 @@ tao-macros 0.1.3 (Apache-2.0 OR MIT)
 https://github.com/tauri-apps/tao
 ---------------------------------------------------------
 
-tauri 2.0.6 (Apache-2.0 OR MIT)
+tauri 2.1.1 (Apache-2.0 OR MIT)
 https://github.com/tauri-apps/tauri
 ---------------------------------------------------------
 
-tauri-codegen 2.0.2 (Apache-2.0 OR MIT)
+tauri-codegen 2.0.3 (Apache-2.0 OR MIT)
 https://github.com/tauri-apps/tauri
 ---------------------------------------------------------
 
-tauri-macros 2.0.2 (Apache-2.0 OR MIT)
+tauri-macros 2.0.3 (Apache-2.0 OR MIT)
 https://github.com/tauri-apps/tauri
 ---------------------------------------------------------
 
@@ -1661,15 +1661,15 @@ tauri-plugin-shell 2.0.2 (Apache-2.0 OR MIT)
 https://github.com/tauri-apps/plugins-workspace
 ---------------------------------------------------------
 
-tauri-runtime 2.1.1 (Apache-2.0 OR MIT)
+tauri-runtime 2.2.0 (Apache-2.0 OR MIT)
 https://github.com/tauri-apps/tauri
 ---------------------------------------------------------
 
-tauri-runtime-wry 2.1.2 (Apache-2.0 OR MIT)
+tauri-runtime-wry 2.2.0 (Apache-2.0 OR MIT)
 https://github.com/tauri-apps/tauri
 ---------------------------------------------------------
 
-tauri-utils 2.0.2 (Apache-2.0 OR MIT)
+tauri-utils 2.1.0 (Apache-2.0 OR MIT)
 https://github.com/tauri-apps/tauri
 ---------------------------------------------------------
 
@@ -1677,7 +1677,7 @@ tauri-winrt-notification 0.2.1 (Apache-2.0 OR MIT)
 https://github.com/tauri-apps/winrt-notification
 ---------------------------------------------------------
 
-tempfile 3.13.0 (Apache-2.0 OR MIT)
+tempfile 3.14.0 (Apache-2.0 OR MIT)
 https://github.com/Stebalien/tempfile
 ---------------------------------------------------------
 
@@ -1689,15 +1689,23 @@ thin-slice 0.1.1 (MPL-2.0)
 https://github.com/heycam/thin-slice
 ---------------------------------------------------------
 
-thiserror 1.0.68 (Apache-2.0 OR MIT)
+thiserror 1.0.69 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/thiserror
 ---------------------------------------------------------
 
-thiserror-impl 1.0.68 (Apache-2.0 OR MIT)
+thiserror 2.0.3 (Apache-2.0 OR MIT)
 https://github.com/dtolnay/thiserror
 ---------------------------------------------------------
 
-thread-priority 1.1.0 (MIT)
+thiserror-impl 1.0.69 (Apache-2.0 OR MIT)
+https://github.com/dtolnay/thiserror
+---------------------------------------------------------
+
+thiserror-impl 2.0.3 (Apache-2.0 OR MIT)
+https://github.com/dtolnay/thiserror
+---------------------------------------------------------
+
+thread-priority 1.2.0 (MIT)
 https://github.com/iddm/thread-priority
 ---------------------------------------------------------
 
@@ -1717,7 +1725,7 @@ tinystr 0.7.6 (Unicode-3.0)
 https://github.com/unicode-org/icu4x
 ---------------------------------------------------------
 
-tokio 1.41.0 (MIT)
+tokio 1.41.1 (MIT)
 https://github.com/tokio-rs/tokio
 ---------------------------------------------------------
 
@@ -2169,7 +2177,7 @@ writeable 0.5.5 (Unicode-3.0)
 https://github.com/unicode-org/icu4x
 ---------------------------------------------------------
 
-wry 0.46.3 (Apache-2.0 OR MIT)
+wry 0.47.0 (Apache-2.0 OR MIT)
 https://github.com/tauri-apps/wry
 ---------------------------------------------------------
 

--- a/src-tauri/gen/schemas/desktop-schema.json
+++ b/src-tauri/gen/schemas/desktop-schema.json
@@ -84,7 +84,7 @@
           }
         },
         "permissions": {
-          "description": "List of permissions attached to this capability.\n\nMust include the plugin name as prefix in the form of `${plugin-name}:${permission-name}`. For commands directly implemented in the application itself only `${permission-name}` is required.\n\n## Example\n\n```json [ \"core:default\", \"shell:allow-open\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] } ```",
+          "description": "List of permissions attached to this capability.\n\nMust include the plugin name as prefix in the form of `${plugin-name}:${permission-name}`. For commands directly implemented in the application itself only `${permission-name}` is required.\n\n## Example\n\n```json [ \"core:default\", \"shell:allow-open\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] } ] ```",
           "type": "array",
           "items": {
             "$ref": "#/definitions/PermissionEntry"

--- a/src-tauri/gen/schemas/windows-schema.json
+++ b/src-tauri/gen/schemas/windows-schema.json
@@ -84,7 +84,7 @@
           }
         },
         "permissions": {
-          "description": "List of permissions attached to this capability.\n\nMust include the plugin name as prefix in the form of `${plugin-name}:${permission-name}`. For commands directly implemented in the application itself only `${permission-name}` is required.\n\n## Example\n\n```json [ \"core:default\", \"shell:allow-open\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] } ```",
+          "description": "List of permissions attached to this capability.\n\nMust include the plugin name as prefix in the form of `${plugin-name}:${permission-name}`. For commands directly implemented in the application itself only `${permission-name}` is required.\n\n## Example\n\n```json [ \"core:default\", \"shell:allow-open\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] } ] ```",
           "type": "array",
           "items": {
             "$ref": "#/definitions/PermissionEntry"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -80,7 +80,7 @@
         "fullscreen": false,
         "height": 600,
         "resizable": true,
-        "title": "AUTD3 Server v29.0.0-rc.5",
+        "title": "AUTD3 Server v29.0.0-rc.8",
         "width": 800
       }
     ],

--- a/src/lib/RightPanel.svelte
+++ b/src/lib/RightPanel.svelte
@@ -2,21 +2,21 @@
 <script lang="ts">
   import { consoleOutputQueue } from "./UI/console_output.ts";
   import { listen } from "@tauri-apps/api/event";
-  import { afterUpdate, onMount } from "svelte";
+  import { onMount } from "svelte";
 
   let element: HTMLTextAreaElement;
 
-  afterUpdate(() => {
+  $effect(() => {
     element.scroll({ top: element.scrollHeight, behavior: "smooth" });
   });
 
-  let console_output = "";
-  $: {
+  let console_output = $state("");
+  $effect(() => {
     while ($consoleOutputQueue.length > 100) {
       $consoleOutputQueue.shift();
     }
     console_output = $consoleOutputQueue.join("\n");
-  }
+  });
 
   onMount(async () => {
     await listen("console-emu", (event) => {

--- a/src/lib/UI/SOEM.svelte
+++ b/src/lib/UI/SOEM.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { run } from "svelte/legacy";
-
   import type { SOEMOptions, TimerStrategy } from "./options.ts";
   import { TimerStrategyValues } from "./options.ts";
 
@@ -48,31 +46,31 @@
   let stateCheckIntervalMs = $state(
     msFromDuration(soemOptions.state_check_interval),
   );
-  run(() => {
+  $effect(() => {
     soemOptions.state_check_interval = msToDuration(stateCheckIntervalMs);
   });
 
   let sendUs = $state(usFromDuration(soemOptions.send));
-  run(() => {
+  $effect(() => {
     soemOptions.send = usToDuration(sendUs);
   });
   let sync0Us = $state(usFromDuration(soemOptions.sync0));
-  run(() => {
+  $effect(() => {
     soemOptions.sync0 = usToDuration(sync0Us);
   });
 
   let syncToleranceUs = $state(usFromDuration(soemOptions.sync_tolerance));
-  run(() => {
+  $effect(() => {
     soemOptions.sync_tolerance = usToDuration(syncToleranceUs);
   });
   let syncTimeoutS = $state(sFromDuration(soemOptions.sync_timeout));
-  run(() => {
+  $effect(() => {
     soemOptions.sync_timeout = sToDuration(syncTimeoutS);
   });
 
   let adapterNames: string[] = $state([]);
   let adapterName: string = $state("Auto");
-  run(() => {
+  $effect(() => {
     if (adapterName == "Auto") {
       soemOptions.ifname = "Auto";
     } else {
@@ -126,7 +124,7 @@
       handleCloseClick();
     });
     command.on("close", async (data) => {
-      if (data.code < -1) {
+      if (data.code != null && data.code < -1) {
         alert(`SOEMAUTDServer exited with code ${data.code}`);
       }
       handleCloseClick();

--- a/src/lib/UI/TwinCAT.svelte
+++ b/src/lib/UI/TwinCAT.svelte
@@ -38,17 +38,6 @@
     await handleCloseClick();
     running = true;
 
-    if (twincatOptions) {
-      let args = {
-        twincatOptions: JSON.stringify(twincatOptions),
-      };
-      try {
-        await invoke("run_twincat_server", args);
-      } catch (err) {
-        alert(err);
-      }
-    }
-
     if (twincatOptions.lightweight) {
       const args: string[] = ["-p", twincatOptions.lightweight_port.toString()];
       command = Command.sidecar("TwinCATAUTDServerLightweight", args);
@@ -65,6 +54,15 @@
       );
       command.on("error", () => handleCloseClick());
       command.on("close", () => handleCloseClick());
+    } else {
+      const args = {
+        twincatOptions: JSON.stringify(twincatOptions),
+      };
+      try {
+        await invoke("run_twincat_server", args);
+      } catch (err) {
+        alert(err);
+      }
     }
 
     running = false;

--- a/src/lib/UI/TwinCAT.svelte
+++ b/src/lib/UI/TwinCAT.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { run } from "svelte/legacy";
-
   import type { TwinCATOptions } from "./options.ts";
 
   import { Command, Child } from "@tauri-apps/plugin-shell";
@@ -13,8 +11,6 @@
   import NumberInput from "./utils/NumberInput.svelte";
   import IpInput from "./utils/IpInput.svelte";
 
-  import { usFromDuration, usToDuration } from "./utils/duration.ts";
-
   interface Props {
     twincatOptions: TwinCATOptions;
   }
@@ -22,15 +18,15 @@
   let { twincatOptions = $bindable() }: Props = $props();
 
   let baseUs = $state(twincatOptions.base * 500);
-  run(() => {
+  $effect(() => {
     twincatOptions.base = baseUs / 500;
   });
   let sync0Us = $state(twincatOptions.sync0 * 500);
-  run(() => {
+  $effect(() => {
     twincatOptions.sync0 = sync0Us / 500;
   });
   let taskUs = $state(twincatOptions.task * 500);
-  run(() => {
+  $effect(() => {
     twincatOptions.task = taskUs / 500;
   });
 

--- a/tools/license-checker/Cargo.lock
+++ b/tools/license-checker/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "autd3-license-check"
-version = "0.4.0"
+version = "29.0.0-rc.8"
 dependencies = [
  "anyhow",
  "cargo-license 0.6.1",
@@ -811,7 +811,7 @@ checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "license-checker"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 dependencies = [
  "anyhow",
  "autd3-license-check",

--- a/tools/license-checker/Cargo.toml
+++ b/tools/license-checker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "license-checker"
-version = "29.0.0-rc.5"
+version = "29.0.0-rc.8"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
- **bump to v29.0.0-rc.8**
- **add simulator server shutdown log**
- **update deprecated methods**
- **fix TwinCATServer lightweight mode**
